### PR TITLE
configure tox

### DIFF
--- a/spotifyutils/playlists/__init__.py
+++ b/spotifyutils/playlists/__init__.py
@@ -2,7 +2,12 @@ import argparse
 import os
 
 
-def cli():
+def cli(input_args=None):
+    """Main playlist program entrypoint
+
+    >>> cli(['--access-token', 'asdf'])
+    {'access_token': 'asdf'}
+    """
     parser = argparse.ArgumentParser(
         description='Utilities that interact with Spotify playlists'
     )
@@ -14,7 +19,7 @@ def cli():
         help='Spotify OAuth access token'
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(input_args)
     main(**vars(args))
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py38
+
+[testenv]
+deps = pytest
+commands = pytest --doctest-modules


### PR DESCRIPTION
Start with Python 3.8 only. Includes a simple "doctest" so that the tests are shown to run.

Install tox locally via"

```shell
pip install tox
```