### PR TITLE
Add authorization configuration variables

### DIFF
--- a/spotifyutils/playlists/__init__.py
+++ b/spotifyutils/playlists/__init__.py
@@ -13,10 +13,22 @@ def cli(input_args=None):
     )
 
     parser.add_argument(
-        '--access-token',
+        '--client-id',
         type=str,
-        required=True,
-        help='Spotify OAuth access token'
+        default=os.getenv('SPOTIFY_CLIENT_ID'),
+        help='Spotify Client ID'
+    )
+    parser.add_argument(
+        '--client-secret',
+        type=str,
+        default=os.getenv('SPOTIFY_CLIENT_SECRET'),
+        help='Spotify client secret'
+    )
+    parser.add_argument(
+        '--redirect-uri',
+        type=str,
+        default='http://localhost:8082',
+        help='Redirect URI (used for authentication)'
     )
 
     args = parser.parse_args(input_args)

--- a/spotifyutils/playlists/__init__.py
+++ b/spotifyutils/playlists/__init__.py
@@ -5,8 +5,8 @@ import os
 def cli(input_args=None):
     """Main playlist program entrypoint
 
-    >>> cli(['--access-token', 'asdf'])
-    {'access_token': 'asdf'}
+    >>> cli(['--client-id', 'asdf'])
+    {'client_id': 'asdf', 'client_secret': None, 'redirect_uri': 'http://localhost:8082'}
     """
     parser = argparse.ArgumentParser(
         description='Utilities that interact with Spotify playlists'

--- a/spotifyutils/playlists/__main__.py
+++ b/spotifyutils/playlists/__main__.py
@@ -1,5 +1,4 @@
 from spotifyutils.playlists import cli
 
 
-if __name__ == '__main__':
-    cli()
+cli()

--- a/spotifyutils/playlists/__main__.py
+++ b/spotifyutils/playlists/__main__.py
@@ -1,4 +1,5 @@
 from spotifyutils.playlists import cli
 
 
-cli()
+if __name__ == '__main__':
+    cli()

--- a/spotifyutils/playlists/__main__.py
+++ b/spotifyutils/playlists/__main__.py
@@ -1,0 +1,5 @@
+from spotifyutils.playlists import cli
+
+
+if __name__ == '__main__':
+    cli()


### PR DESCRIPTION
It is considered good practice to provide secret credentials via environment variables, as this protects against certain attacks. Here, we provide a mechanism to specify these as both command-line arguments, and fall back to environment variables by default. This can make things easier to test.

The program entrypoint is also modified slightly, to accommodate two ways in which to execute the script.

1. As an installed script:
```bash
pip install .
spotifyplaylists --help
```
2. As a python module
```bash
python -m spotifyutils.playlists
```