### PR TITLE
Support modules for performing Spotify Auth Code flow

### DIFF
--- a/spotifyutils/__init__.py
+++ b/spotifyutils/__init__.py
@@ -1,18 +1,20 @@
 import argparse
 import os
 
+import spotifyutils.config
+
 
 def cli(input_args=None):
-    """Main playlist program entrypoint
-
-    >>> cli(['config', '--client-id', 'asdf'])
-    Test
+    """Main program entrypoint
     """
     parser = argparse.ArgumentParser(
         description='Utilities that interact with Spotify playlists'
     )
 
-    subparsers = parser.add_subparsers(help='sub-command help')
+    subparsers = parser.add_subparsers(
+        help='sub-command help',
+        dest='command'
+    )
 
     # Configuration command
     parser_config = subparsers.add_parser(
@@ -25,21 +27,19 @@ def cli(input_args=None):
         help='Spotify Client ID'
     )
     parser_config.add_argument(
-        '--client-secret',
+        '--secret-id',
         type=str,
-        default=os.getenv('SPOTIFY_CLIENT_SECRET'),
-        help='Spotify client secret'
+        default=os.getenv('SPOTIFY_SECRET_ID'),
+        help='Spotify secret ID'
     )
     parser_config.add_argument(
         '--redirect-uri',
         type=str,
-        default='http://localhost:8082',
         help='Redirect URI (used for authentication)'
     )
     parser_config.add_argument(
         '--configfile',
         type=str,
-        default=os.path.join(os.path.expanduser('~'), '.spotifyutils'),
         help='Location on the filesystem to store configuration parameters'
     )
 
@@ -53,4 +53,7 @@ def cli(input_args=None):
 
 
 def main(**kwargs):
-    print('Test')
+    command = kwargs['command']
+
+    if command == 'config':
+        spotifyutils.config.run(**kwargs)

--- a/spotifyutils/auth.py
+++ b/spotifyutils/auth.py
@@ -1,0 +1,214 @@
+"""This module handles Spotify authentication.
+
+Since these utilities, in general, require access to user private data, we are
+required to follow the Authorization Code Flow. This flow requires additional
+steps and complexity versus the simpler Application flow. See:
+https://developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow
+
+At a high level, the flow is implemented as follows:
+
+1. In the Spotify developer dashboard
+(https://developer.spotify.com/dashboard/applications), create a client ID.
+
+2. Add a redirect URI as https://localhost:8084/callback
+
+3. Generate a valid Spotify Auth URI using the client ID, redirect URI,
+required OAuth scopes, and optionally a state to be used in verification (if
+desired, but due to the short-lived nature of the redirect handler, it is low
+risk to exclude).
+
+4. Start the redirect handler HTTPS server, which creates a temporary
+self-signed certificate.
+
+5. Open the generated Spotify Auth URI in a web browser, and authenticate.
+
+6. Once Spotify completes authentication, it will redirect to the provided
+redirect URI /callback handler. The /callback handler parses the code out of
+the query parameters, and returns the code to the user.
+
+Usage:
+
+>>> client_id = 'asdf'
+>>> client_secret = 'asdf2'
+>>> redirect_uri = 'https://localhost:8084/callback'
+>>> scopes = ['read-playlist', 'write-playlist']
+>>> state = '123'
+>>> auth_uri = spotify_auth_uri(client_id, redirect_uri, scopes, state)
+>>> code = wait_for_auth_redirect(redirect_uri)
+>>> access_token, refresh_token = get_tokens(code, client_id, client_secret, redirect_uri)
+
+"""
+import base64
+import http.server
+import json
+import ssl
+import tempfile
+import urllib.parse
+import urllib.request
+
+from spotifyutils.cert import generate_selfsigned_cert
+from typing import List
+
+
+# singletons/globals
+_REDIRECT_URI = None
+_AUTH_CODE = None
+
+
+class _SpotifyAuthHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, *args, **kwargs):
+        """Disable internal logging
+
+        Logging is handled by BaseHTTPRequestHandler.log_message(). We replace
+        this method with a noop. Otherwise, it pollutes stdout. Since we are
+        not operating a proper production server, this logging is unnecessary
+        for this application.
+
+        See: https://stackoverflow.com/questions/20281709/how-do-you-override-basehttprequesthandler-log-message-method-to-log-to-a-file
+
+        """
+
+    def do_GET(self):
+        """Handle Spotify authentication redirect"""
+        global _AUTH_CODE
+        global _REDIRECT_URI
+
+        self.protocol_version = 'HTTP/1.1'
+
+        # We will route the request based on endpoint, so parse it out of the
+        # request.
+        endpoint = urllib.parse.urlparse(self.path).path
+
+        # If the request is to the token endpoint, we are expecting the auth
+        # code to be in the query parameters, as set by the /callback endpoint.
+        if endpoint == urllib.parse.urlparse(_REDIRECT_URI).path:
+            params = urllib.parse.parse_qs(
+                urllib.parse.urlparse(self.path).query
+            )
+            _AUTH_CODE = params['code'][0]
+
+            self.send_response(200, 'OK')
+            self.send_header('Content-Type', 'text/html')
+            self.end_headers()
+
+            self.wfile.write('Close me!'.encode())
+
+        # Default response for all other requests that aren't /callback
+        else:
+            self.send_response(404, 'NOT FOUND')
+
+
+def secure_server(http_server, host):
+    """Wrap the http server in a secure socket"""
+    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+
+    # create a temporary, throwaway certificate
+    cert, private = generate_selfsigned_cert(host)
+
+    # these files are deleted after the context exists
+    with tempfile.NamedTemporaryFile() as cert_file:
+        with tempfile.NamedTemporaryFile() as key_file:
+
+            cert_file.write(cert)
+            key_file.write(private)
+            cert_file.flush()
+            key_file.flush()
+
+            ssl_context.load_cert_chain(
+                cert_file.name, key_file.name
+            )
+
+    http_server.socket = ssl_context.wrap_socket(http_server.socket, server_side=True)
+
+    return http_server
+
+
+def wait_for_auth_redirect(redirect_uri: str) -> str:
+    """Run a temporary web server in order to wait for a Spotify auth redirect
+
+    Blocks until Spotify returns from a redirect for authentication.
+    """
+
+    global _AUTH_CODE
+    global _REDIRECT_URI
+
+    if _AUTH_CODE:
+        return _AUTH_CODE
+    else:
+
+        _REDIRECT_URI = redirect_uri
+
+        # TODO wrap this in a ValueError exception when there is an invalid URI
+        # format. Reraise as something like ValueError('Invalid URI Format').
+        host, port = urllib.parse.urlparse(redirect_uri).netloc.split(':')
+
+        # block waiting for a request
+        with http.server.HTTPServer(
+                (host, int(port)),
+                _SpotifyAuthHTTPRequestHandler
+        ) as server:
+            server = secure_server(server, host)
+
+            while not _AUTH_CODE:
+                server.handle_request()
+
+    return _AUTH_CODE
+
+
+def spotify_auth_uri(
+        client_id: str, redirect_uri: str, scopes: List[str], state: str=None
+):
+    """Build a request for the user to navigate to
+
+    Usage:
+    >>> cid = 'asdf'
+    >>> redirect_uri = 'http://localhost'
+    >>> scopes = ['read-playlist', 'write-playlist']
+    >>> state = '123'
+    >>> spotify_auth_uri(cid, redirect_uri, scopes, state)
+    'https://accounts.spotify.com/authorize?client_id=asdf&scope=read-playlist+write-playlist&redirect_uri=http%3A%2F%2Flocalhost&state=123'
+    """
+
+    base_url = 'https://accounts.spotify.com/authorize' 
+    query_params = urllib.parse.urlencode(
+        {
+            'client_id': client_id,
+            'scope': ' '.join(scopes),
+            'redirect_uri': redirect_uri,
+            'state': state,
+            'response_type': 'code',
+        }
+    )
+
+    full_url = base_url + '?' + query_params
+
+    return full_url
+
+
+def get_tokens(
+        auth_code,
+        client_id,
+        client_secret,
+        redirect_uri,
+        url: str='https://accounts.spotify.com/api/token/'
+) -> dict:
+    """Returns (access_token, refresh_token)"""
+    # encode the data, if it exists
+    encoded_data = urllib.parse.urlencode(
+        {
+            'grant_type': 'authorization_code',
+            'code': auth_code,
+            'redirect_uri': redirect_uri,
+        }
+    ).encode('ascii')
+
+    headers = {
+        'Authorization' : 'Basic ' + base64.standard_b64encode(
+            f'{client_id}:{client_secret}'.encode()
+        ).decode('ascii')
+    }
+    request = urllib.request.Request(url, encoded_data, headers)
+    with urllib.request.urlopen(request) as response:
+        payload = json.loads(response.read())
+
+        return payload['access_token'], payload['refresh_token']

--- a/spotifyutils/cert.py
+++ b/spotifyutils/cert.py
@@ -1,0 +1,88 @@
+# Copyright 2018 Simon Davy
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# WARNING: the code in the gist generates self-signed certs, for the purposes of testing in development.
+# Do not use these certs in production, or You Will Have A Bad Time.
+#
+# Caveat emptor
+#
+
+from datetime import datetime, timedelta
+import ipaddress
+import random
+
+def generate_selfsigned_cert(hostname, ip_addresses=None, key=None):
+    """Generates self signed certificate for a hostname, and optional IP addresses."""
+    from cryptography import x509
+    from cryptography.x509.oid import NameOID
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    # Generate our key
+    if key is None:
+        key = rsa.generate_private_key(
+            public_exponent=65537,
+            key_size=2048,
+            backend=default_backend(),
+        )
+
+    name = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, hostname)
+    ])
+
+    # best practice seem to be to include the hostname in the SAN, which *SHOULD* mean COMMON_NAME is ignored.
+    alt_names = [x509.DNSName(hostname)]
+
+    # allow addressing by IP, for when you don't have real DNS (common in most testing scenarios
+    if ip_addresses:
+        for addr in ip_addresses:
+            # openssl wants DNSnames for ips...
+            alt_names.append(x509.DNSName(addr))
+            # ... whereas golang's crypto/tls is stricter, and needs IPAddresses
+            # note: older versions of cryptography do not understand ip_address objects
+            alt_names.append(x509.IPAddress(ipaddress.ip_address(addr)))
+
+    san = x509.SubjectAlternativeName(alt_names)
+
+    # path_len=0 means this cert can only sign itself, not other certs.
+    basic_contraints = x509.BasicConstraints(ca=True, path_length=0)
+    now = datetime.utcnow()
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(int(datetime.now().timestamp()))
+        .not_valid_before(now)
+        .not_valid_after(now + timedelta(days=10*365))
+        .add_extension(basic_contraints, False)
+        .add_extension(san, False)
+        .sign(key, hashes.SHA256(), default_backend())
+    )
+    cert_pem = cert.public_bytes(encoding=serialization.Encoding.PEM)
+    key_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+    return cert_pem, key_pem

--- a/spotifyutils/config.py
+++ b/spotifyutils/config.py
@@ -1,0 +1,57 @@
+import os
+
+from getpass import getpass
+from spotifyutils.auth import spotify_auth_uri, wait_for_auth_redirect, get_tokens
+
+
+DEFAULTS = {
+    'redirect_uri': 'https://localhost:8084/callback',
+    'configfile': os.path.join(os.path.expanduser('~'), '.spotifyutils'),
+}
+
+
+def run(**kwargs):
+    """Perform configuration, including initial authentication"""
+
+    # TODO read from config file as well
+    client_id = kwargs['client_id'] or input('Client ID: ')
+    secret_id = kwargs['secret_id'] or getpass('Secret ID: ')
+    redirect_uri = kwargs['redirect_uri'] or input(f'Redirect URI [{DEFAULTS["redirect_uri"]}]: ') or DEFAULTS['redirect_uri']
+    configfile = kwargs['configfile'] or input(f'Configfile [{DEFAULTS["configfile"]}]: ') or DEFAULTS['configfile']
+
+    # TODO find a better home for these
+    scopes = ['playlist-read-private', 'playlist-modify-private']
+
+    # Get an authorization code, access token and/or refresh token
+    print('')
+    print('TODO include instructions for setting up Spotify developer dashboard and project')
+
+    print('')
+    print('Browse to: ' + spotify_auth_uri(client_id, redirect_uri, scopes, '123'))
+
+    print('')
+    print('Note: This program generates a self-signed certificate for the redirect callback server. Your browser will likely prompt you before you can continue.')
+
+    print('')
+    print(f'Listening for redirect from Spotify at {redirect_uri}...')
+
+    auth_code = wait_for_auth_redirect(redirect_uri)
+
+    print('')
+    print(f'Received an Authorization Code from Spotify for user {client_id}')
+
+    print('')
+    print('Requesting Access and Refresh tokens from Spotify...')
+
+    access_token, refresh_token = get_tokens(code, client_id, client_secret, redirect_uri)
+
+    print('')
+    print('Got access and refresh tokens from Spotify')
+
+    # TODO save everything to the config file
+
+    print('')
+    print(f'Configuration saved to {configfile}')
+
+    print('')
+    print('Configuration complete')

--- a/tests/test_nothing.py
+++ b/tests/test_nothing.py
@@ -1,0 +1,3 @@
+
+def test_nothing():
+    assert True

--- a/tox.ini
+++ b/tox.ini
@@ -3,4 +3,4 @@ envlist = py38
 
 [testenv]
 deps = pytest
-commands = pytest --doctest-modules
+commands = pytest


### PR DESCRIPTION
At a high level, the flow is implemented as follows:

1. In the Spotify developer dashboard
(https://developer.spotify.com/dashboard/applications), create a client ID.

2. Add a redirect URI as https://localhost:8084/callback

3. Generate a valid Spotify Auth URI using the client ID, redirect URI,
required OAuth scopes, and optionally a state to be used in verification (if
desired, but due to the short-lived nature of the redirect handler, it is low
risk to exclude).

4. Start the redirect handler HTTPS server, which creates a temporary
self-signed certificate.

5. Open the generated Spotify Auth URI in a web browser, and authenticate.

6. Once Spotify completes authentication, it will redirect to the provided
redirect URI /callback handler. The /callback handler parses the code out of
the query parameters, and returns the code to the user.

Implement example Spotify auth flow via config command

The command will walk through the entire authentication flow, but will not save
it or do anything with it.

usage: __main__.py config [-h] [--client-id CLIENT_ID] [--secret-id SECRET_ID] [--redirect-uri REDIRECT_URI] [--configfile CONFIGFILE]

optional arguments:
  -h, --help            show this help message and exit
  --client-id CLIENT_ID
                        Spotify Client ID
  --secret-id SECRET_ID
                        Spotify secret ID
  --redirect-uri REDIRECT_URI
                        Redirect URI (used for authentication)
  --configfile CONFIGFILE
                        Location on the filesystem to store configuration parameters

Replace doctests with proper test folder

For now, the tests do nothing at all, but we need at least one for tox to not
fail the build.