### PR TITLE
Fix use of multiple scopes

### DIFF
--- a/spotifyutils/auth.py
+++ b/spotifyutils/auth.py
@@ -20,14 +20,14 @@ def user_auth(redirect_uri: str, client_id: str):
     REDIRECT_URI = redirect_uri
     base_url = "https://accounts.spotify.com/authorize"
     response_type = 'code'
-    scope = ['user-read-email']
+    scope = ['user-read-email', 'playlist-read-private', 'user-read-private']
     show_dialog = 'true'
 
     PARAMS = {
         'client_id': client_id,
         'response_type': response_type,
         'redirect_uri': redirect_uri,
-        'scope': (''.join(scope)),
+        'scope': (','.join(scope)),
         'show_dialog': show_dialog
     }
 


### PR DESCRIPTION
### Summary
When multiple scopes are specified, they must be delimited with commas.